### PR TITLE
Use assoc to get chemacs profile.

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -53,7 +53,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun chemacs-get-emacs-profile (profile)
-  (alist-get profile chemacs-emacs-profiles nil nil #'equal))
+  (assoc profile chemacs-emacs-profiles))
 
 (defun chemacs-emacs-profile-key (key &optional default)
   (alist-get key (chemacs-get-emacs-profile chemacs-current-emacs-profile)


### PR DESCRIPTION
New to elisp, just find the function that works in [Association Lists](https://www.gnu.org/software/emacs/manual/html_node/elisp/Association-Lists.html)