### PR TITLE
Fixed the connect-the-dots URL syntax

### DIFF
--- a/README.org
+++ b/README.org
@@ -146,7 +146,7 @@ Other things you can configure
 
 Store =.emacs-profile.el= together with your dotfiles. If you're not yet keeping
 a version controlled directory of dotfiles, then check out
-[connect-the-dots](https://github.com/plexus/dotfiles/blob/master/connect-the-dots)
+[[https://github.com/plexus/dotfiles/blob/master/connect-the-dots][connect-the-dots]]
 for a helpful script to do that.
 
 ** Spacemacs


### PR DESCRIPTION
Earlier markdown syntax was used.