### PR TITLE
Allow selection of default profile using a file

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -32,6 +32,9 @@
 ;;                                         (custom-file . "~/.spacemacs.d/custom.el")
 ;;                                         (env . (("SPACEMACSDIR" . "~/.spacemacs.d"))))))
 ;;
+;; If you want to change the default profile used (so that, for example, a
+;; GUI version of Emacs uses the profile you want), you can also put the name
+;; of that profile in a ~/.emacs-profile file
 
 ;; ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ;; this must be here to keep the package system happy, normally you do
@@ -39,6 +42,7 @@
 ;; (package-initialize)
 
 (setq chemacs-profiles-path "~/.emacs-profiles.el")
+(setq chemacs-default-profile-path "~/.emacs-profile")
 
 (when (not (file-exists-p chemacs-profiles-path))
   (with-temp-file chemacs-profiles-path
@@ -49,6 +53,14 @@
         (insert-file-contents chemacs-profiles-path)
         (goto-char (point-min))
         (read (current-buffer))))
+
+(setq chemacs-default-profile
+      (if (file-exists-p chemacs-default-profile-path)
+          (with-temp-buffer
+            (insert-file-contents chemacs-default-profile-path)
+            (goto-char (point-min))
+            (read (current-buffer)))
+        "default"))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -106,4 +118,4 @@
 
 ;; Or if none given, load the "default" profile
 (when (not (member "--with-profile" command-line-args))
-  (chemacs-load-profile "default"))
+  (chemacs-load-profile (chemacs-default-profile)))

--- a/README.org
+++ b/README.org
@@ -149,6 +149,36 @@ a version controlled directory of dotfiles, then check out
 [[https://github.com/plexus/dotfiles/blob/master/connect-the-dots][connect-the-dots]]
 for a helpful script to do that.
 
+** Changing the default profile (e.g. for GUI editors)
+
+Where it is not possible to use the =--with-profile= flag, the default profile
+can be set using a =~/.emacs-profile= file.
+
+If your =~/.emacs-profiles.el= file contains the following:
+
+#+BEGIN_SRC emacs-lisp
+  (("default" . ((user-emacs-directory . "~/.emacs.d")))
+   ("spacemacs" . ((user-emacs-directory . "~/spacemacs")
+   ("prelude" . ((user-emacs-directory . "~/prelude"))))
+#+END_SRC
+
+you can create a file called =~/.emacs-profile=, containing the name of the
+profile you'd like to be used when none is given on the command line:
+
+#+BEGIN_SRC shell
+$ echo 'spacemacs' > ~/.emacs-profile
+#+END_SRC
+
+This will set the default profile to be the "spacemacs" profile, instead of
+"default". You can change the default by simply changing the contents of this
+file:
+
+#+BEGIN_SRC shell
+$ echo 'prelude' > ~/.emacs-profile
+#+END_SRC
+
+If this file doesn't exist, then "default" will be used, as before.
+
 ** Spacemacs
 
 Spacemacs is typically installed by cloning the Spacemacs repo to =~/.emacs.d=,


### PR DESCRIPTION
For GUI versions of emacs, it's not possible to start them with a `--with-profile` flag. In these cases, it's helpful to be able to control which profile is loaded using something in the filesystem. This change allows switching of the default profile using the contents of a `~/.emacs-profile` file, which should contain the string of the profile to be used (e.g. "spacemacs" or "doom" or "default").

If the file is not present, "default" will be used as before.