### PR TITLE
Fix bug in `.emacs-profile` handling

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -59,7 +59,7 @@
           (with-temp-buffer
             (insert-file-contents chemacs-default-profile-path)
             (goto-char (point-min))
-            (read (current-buffer)))
+            (symbol-name (read (current-buffer))))
         "default"))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Having run `echo 'spacemacs' > ~/.emacs-profile`, the `.emacs` init script complained that it could not find a profile `spacemacs` in my set. I believe this is because the value was being turned into a symbol, e.g. `spacemacs` would not be found, but `"spacemacs"` could be. To fix this, I needed to turn the read value explicitly into a string.