### PR TITLE
Prevent init-file from loading twice

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -121,7 +121,8 @@
     ;; set a value for custom-file then don't touch it.
     (when (not custom-file)
       (setq custom-file custom-file-)
-      (load custom-file))))
+      (unless (equal custom-file init-file)
+        (load custom-file)))))
 
 (defun chemacs-check-command-line-args (args)
   (if args


### PR DESCRIPTION
When there is no `custom-file` specified, it defaults to `init-file`. Both must be loaded, so the `init-file` would be loaded twice. This only loads `custom-file` if it's *different* from `init-file`.

Here's what `*Messages*` looked like before:

```
Loading /home/league/.emacs-profiles/zuru/init.el (source)...
Hello, zuru!
Loading /home/league/.emacs-profiles/zuru/init.el (source)...done
Loading /home/league/.emacs-profiles/zuru/init.el (source)...
Hello, zuru!
Loading /home/league/.emacs-profiles/zuru/init.el (source)...done
For information about GNU Emacs and the GNU system, type C-h C-a.
Mark set
```

And I even added this to init.el to ensure that it wasn't just *messaging* twice for some reason:

```el
(setq zuru-here
 (if (boundp 'zuru-here) (+ 1 zuru-here) 1))
```

Upon startup, indeed `zuru-here` had the value `2`. This PR fixes that, I also tested *with* custom-file set to something.